### PR TITLE
Update Makefile

### DIFF
--- a/ext/stbi/Makefile
+++ b/ext/stbi/Makefile
@@ -8,7 +8,7 @@ stb_image.h:
 	wget https://raw.githubusercontent.com/nothings/stb/master/stb_image.h
 
 stb_image_resize.h:
-	wget https://raw.githubusercontent.com/nothings/stb/master/stb_image_resize.h
+	wget https://raw.githubusercontent.com/nothings/stb/master/deprecated/stb_image_resize.h
 
 stb_image_write.h:
 	wget https://raw.githubusercontent.com/nothings/stb/master/stb_image_write.h


### PR DESCRIPTION
point to the depricated stb_image_resize.h so Mango can build properly.